### PR TITLE
Fix s3Endpoint redeclaration typo

### DIFF
--- a/src/Helpers/media_library_helpers.php
+++ b/src/Helpers/media_library_helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!function_exists('s3Enpoint')) {
+if (!function_exists('s3Endpoint')) {
     function s3Endpoint($disk = 'libraries')
     {
         $scheme = config("filesystems.disks.{$disk}.use_https") ? 'https://' : '';


### PR DESCRIPTION
Fix a with function_exists causes a redeclaration error if s3Endpoint is declared elsewhere.